### PR TITLE
Null function when onChange not specified

### DIFF
--- a/src/components/AutoCompleteV2.component
+++ b/src/components/AutoCompleteV2.component
@@ -97,7 +97,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             });
 
             if({!NOT(ISNULL(onChange))}){
-                $elem.on("select2-selecting",{!IF(ISNULL(onChange)," ",onChange)});
+                $elem.on("select2-selecting",{!IF(ISNULL(onChange),"{}",onChange)});
             }
 
             if({!cacheField !=''}){

--- a/src/components/AutoCompleteV2.component
+++ b/src/components/AutoCompleteV2.component
@@ -97,7 +97,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             });
 
             if({!NOT(ISNULL(onChange))}){
-                $elem.on("select2-selecting",{!IF(ISNULL(onChange),"{}",onChange)});
+                $elem.on("select2-selecting",{!IF(ISNULL(onChange), function(e){},onChange)});
             }
 
             if({!cacheField !=''}){

--- a/src/components/AutoCompleteV2.component
+++ b/src/components/AutoCompleteV2.component
@@ -97,7 +97,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             });
 
             if({!NOT(ISNULL(onChange))}){
-                $elem.on("select2-selecting",{!IF(ISNULL(onChange), function(e){},onChange)});
+                $elem.on("select2-selecting",{!IF(ISNULL(onChange), 'function(e){}',onChange)});
             }
 
             if({!cacheField !=''}){


### PR DESCRIPTION
When onChange was not provided, I was getting a javascript error on Chrome Version 52.0.2743.116 m that prevented select2 from enhancing the search input (rendered as a standard text input box)
